### PR TITLE
Renamed ClimatedDevice and SwitchDevices to entities

### DIFF
--- a/custom_components/nefiteasy/climate.py
+++ b/custom_components/nefiteasy/climate.py
@@ -8,7 +8,10 @@ import asyncio
 import concurrent
 import logging
 
-from homeassistant.components.climate import ClimateDevice
+try:
+    from homeassistant.components.climate import ClimateEntity
+except ImportError:
+    from homeassistant.components.climate import ClimateDevice as ClimateEntity
 from homeassistant.components.climate.const import (SUPPORT_TARGET_TEMPERATURE, SUPPORT_PRESET_MODE,
     CURRENT_HVAC_IDLE, CURRENT_HVAC_HEAT,
     HVAC_MODE_HEAT)
@@ -37,7 +40,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     _LOGGER.debug("climate: async_setup_platform done")
 
 
-class NefitThermostat(ClimateDevice):
+class NefitThermostat(ClimateEntity):
     """Representation of a NefitThermostat device."""
 
     def __init__(self, device):
@@ -99,7 +102,7 @@ class NefitThermostat(ClimateDevice):
 
     @property
     def name(self):
-        """Return the name of the ClimateDevice.
+        """Return the name of the ClimateEntity.
         """
         return self._config.get(CONF_NAME)
 

--- a/custom_components/nefiteasy/nefit_entity.py
+++ b/custom_components/nefiteasy/nefit_entity.py
@@ -9,8 +9,8 @@ from .const import DISPATCHER_ON_DEVICE_UPDATE, CONF_NAME, STATE_CONNECTION_VERI
 
 _LOGGER = logging.getLogger(__name__)
 
-class NefitDevice(Entity):
-    """Representation of a Nefit device."""
+class NefitEntity(Entity):
+    """Representation of a Nefit entity."""
 
     def __init__(self, device, key, typeconf):
         """Initialize the sensor."""

--- a/custom_components/nefiteasy/sensor.py
+++ b/custom_components/nefiteasy/sensor.py
@@ -9,7 +9,7 @@ import logging
 #from homeassistant.core import callback
 
 from .const import DOMAIN, CONF_SENSORS, SENSOR_TYPES
-from .nefit_device import NefitDevice
+from .nefit_entity import NefitEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,8 +34,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     _LOGGER.debug("sensor: async_setup_platform done")
 
 
-class NefitSensor(NefitDevice):
-    """Representation of a NefitSensor device."""
+class NefitSensor(NefitEntity):
+    """Representation of a NefitSensor entity."""
 
     @property
     def state(self):

--- a/custom_components/nefiteasy/switch.py
+++ b/custom_components/nefiteasy/switch.py
@@ -14,7 +14,7 @@ except ImportError:
 from homeassistant.const import STATE_OFF, STATE_ON
 
 from .const import DOMAIN, CONF_SWITCHES, SWITCH_TYPES
-from .nefit_device import NefitDevice
+from .nefit_entity import NefitEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,8 +55,8 @@ async def setup_home_entrance_detection(entities, device, basekey, basetypeconf)
             entities.append(NefitSwitch(device, '{}_{}'.format(basekey, userprofile_id), typeconf))
 
 
-class NefitSwitch(NefitDevice, SwitchEntity):
-    """Representation of a NefitSwitch device."""
+class NefitSwitch(NefitEntity, SwitchEntity):
+    """Representation of a NefitSwitch entity."""
 
     @property
     def is_on(self):

--- a/custom_components/nefiteasy/switch.py
+++ b/custom_components/nefiteasy/switch.py
@@ -7,7 +7,10 @@ https://home-assistant.io/components/xxxxxx/
 import asyncio
 import logging
 
-from homeassistant.components.switch import SwitchDevice
+try:
+    from homeassistant.components.switch import SwitchEntity
+except ImportError:
+    from homeassistant.components.switch import SwitchDevice as SwitchEntity
 from homeassistant.const import STATE_OFF, STATE_ON
 
 from .const import DOMAIN, CONF_SWITCHES, SWITCH_TYPES
@@ -52,7 +55,7 @@ async def setup_home_entrance_detection(entities, device, basekey, basetypeconf)
             entities.append(NefitSwitch(device, '{}_{}'.format(basekey, userprofile_id), typeconf))
 
 
-class NefitSwitch(NefitDevice, SwitchDevice):
+class NefitSwitch(NefitDevice, SwitchEntity):
     """Representation of a NefitSwitch device."""
 
     @property


### PR DESCRIPTION
I'am running the HA 0.110 beta release and noticed the following messages
`2020-05-15 07:57:29 WARNING (MainThread) [homeassistant.components.climate] ClimateDevice is deprecated, modify NefitThermostat to extend ClimateEntity
2020-05-15 07:57:30 WARNING (MainThread) [homeassistant.components.switch] SwitchDevice is deprecated, modify NefitSwitch to extend SwitchEntity
2020-05-15 07:57:30 WARNING (MainThread) [homeassistant.components.switch] SwitchDevice is deprecated, modify NefitHotWater to extend SwitchEntity`

Last night a blog appeared explaining this behaviour. [https://developers.home-assistant.io/blog/2020/05/14/entity-class-names](url)