### PR TITLE
Refactor to use DataUpdateCoordinator

### DIFF
--- a/custom_components/nefiteasy/__init__.py
+++ b/custom_components/nefiteasy/__init__.py
@@ -190,6 +190,7 @@ class NefitEasy(DataUpdateCoordinator):
         )
 
     async def add_key(self, key, typeconf):
+        """Add key to list of endpoints."""
         if url in typeconf:
             self._urls[typeconf[url]] = {"key": key, short: typeconf.get(short)}
         elif short in typeconf:
@@ -356,16 +357,18 @@ class NefitEasy(DataUpdateCoordinator):
             and self.connected_state == STATE_CONNECTION_VERIFIED
         ):
             self._data[self._urls[data["id"]]["key"]] = data["value"]
+        else:
+            return
 
         if self._request == data["id"]:
             self._event.set()
+        else:
+            self.async_set_updated_data(self._data)
 
     async def _async_update_data(self):
         """Update data via library."""
         if self.connected_state != STATE_CONNECTION_VERIFIED:
             raise UpdateFailed("Nefit easy not connected!")
-
-        self._data = {}
 
         url = "/ecus/rrc/uiStatus"
         await self._async_get_url(url)

--- a/custom_components/nefiteasy/const.py
+++ b/custom_components/nefiteasy/const.py
@@ -15,8 +15,6 @@ CONF_TEMP_STEP = "temp_step"
 CONF_SWITCHES = "switches"
 CONF_SENSORS = "sensors"
 
-DISPATCHER_ON_DEVICE_UPDATE = "nefiteasy_{key}_on_device_update"
-
 STATE_CONNECTED = "connected"
 STATE_CONNECTION_VERIFIED = "connection_verified"
 STATE_INIT = "initializing"

--- a/custom_components/nefiteasy/nefit_entity.py
+++ b/custom_components/nefiteasy/nefit_entity.py
@@ -1,84 +1,26 @@
 """Support for Bosch home thermostats."""
 
-import asyncio
 import logging
-from typing import Callable, Dict, List
+from typing import Dict
 
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import (
-    CONF_NAME,
-    CONF_SERIAL,
-    DISPATCHER_ON_DEVICE_UPDATE,
-    DOMAIN,
-    STATE_CONNECTION_VERIFIED,
-)
+from .const import CONF_NAME, CONF_SERIAL, DOMAIN, url
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class NefitEntity(Entity):
+class NefitEntity(CoordinatorEntity):
     """Representation of a Nefit entity."""
 
     def __init__(self, client, data, key, typeconf):
         """Initialize the sensor."""
-        self._client = client
+        super().__init__(client)
+
         self._config = data
         self._typeconf = typeconf
         self._key = key
-        self._unique_id = f"{self._client.nefit.serial_number}_{self._key}"
-
-        self._client.events[key] = asyncio.Event()
-        self._client.data[key] = None
-
-        if "url" in typeconf:
-            self._url = typeconf["url"]
-            self._client.keys[self._url] = key
-
-        if "short" in typeconf:
-            self._client.ui_status_vars[key] = typeconf["short"]
-
-        self._remove_callbacks: List[Callable[[], None]] = []
-
-    async def async_added_to_hass(self) -> None:
-        """Register callbacks when entity is added."""
-        kwargs = {
-            "key": self._key,
-        }
-        self._remove_callbacks.append(
-            async_dispatcher_connect(
-                self.hass,
-                DISPATCHER_ON_DEVICE_UPDATE.format(**kwargs),
-                self.async_schedule_update_ha_state,
-            )
-        )
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Unregister callbacks."""
-        for remove_callback in self._remove_callbacks:
-            remove_callback()
-        self._remove_callbacks = []
-
-        del self._client.events[self._key]
-        if self._key in self._client.ui_status_vars:
-            del self._client.ui_status_vars[self._key]
-
-    async def async_update(self):
-        """Request latest data."""
-        _LOGGER.debug("async_update called for %s", self._key)
-        event = self._client.events[self._key]
-        event.clear()  # clear old event
-        self._client.nefit.get(self.get_endpoint())
-        try:
-            await asyncio.wait_for(event.wait(), timeout=9)
-        except asyncio.TimeoutError:
-            _LOGGER.debug(
-                "Did not get an update in time for %s %s.",
-                self._client.serial,
-                self._key,
-            )
-            event.clear()  # clear event
+        self._unique_id = f"{client.nefit.serial_number}_{self._key}"
 
     @property
     def name(self):
@@ -91,26 +33,10 @@ class NefitEntity(Entity):
         return self._unique_id
 
     @property
-    def should_poll(self) -> bool:
-        """Return if entity should poll."""
-        if self._client.connected_state == STATE_CONNECTION_VERIFIED:
-            # Enable polling if value does not exist in uiStatus
-            if "short" in self._typeconf:
-                return False
-
-            return True
-
-        return False
-
-    @property
     def icon(self):
         """Return possible sensor specific icon."""
         if "icon" in self._typeconf:
             return self._typeconf["icon"]
-
-    def get_endpoint(self):
-        """Return the API endpoint."""
-        return self._url
 
     @property
     def device_info(self) -> Dict[str, any]:
@@ -120,3 +46,12 @@ class NefitEntity(Entity):
             "name": self._config[CONF_NAME],
             "manufacturer": "Bosch",
         }
+
+    async def async_added_to_hass(self):
+        """Add required data to coordinator."""
+        await super().async_added_to_hass()
+        await self.coordinator.add_key(self._key, self._typeconf)
+
+    def get_endpoint(self):
+        """Get end point."""
+        return self._typeconf[url]

--- a/custom_components/nefiteasy/sensor.py
+++ b/custom_components/nefiteasy/sensor.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from .const import CONF_SENSORS, DOMAIN, SENSOR_TYPES
+from .const import DOMAIN, SENSOR_TYPES
 from .nefit_entity import NefitEntity
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/nefiteasy/sensor.py
+++ b/custom_components/nefiteasy/sensor.py
@@ -5,9 +5,6 @@ import logging
 from .const import CONF_SENSORS, DOMAIN, SENSOR_TYPES
 from .nefit_entity import NefitEntity
 
-# from homeassistant.core import callback
-
-
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -36,7 +33,7 @@ class NefitSensor(NefitEntity):
     @property
     def state(self):
         """Return the state/value of the sensor."""
-        return self._client.data[self._key]
+        return self.coordinator.data.get(self._key)
 
     @property
     def device_class(self):
@@ -61,8 +58,13 @@ class NefitYearTotal(NefitSensor):
     @property
     def state(self):
         """Return the state/value of the sensor."""
+        data = self.coordinator.data.get(self._key)
+
+        if data is None:
+            return None
+
         return "{:.1f}".format(
-            self._client.data[self._key] * 0.12307692
+            data * 0.12307692
         )  # convert kWh to m3, for LPG, multiply with 0.040742416
 
 
@@ -72,7 +74,7 @@ class NefitStatus(NefitSensor):
     @property
     def state(self):
         """Return the state/value of the sensor."""
-        return get_status(self._client.data[self._key])
+        return get_status(self.coordinator.data.get(self._key))
 
 
 def get_status(code):

--- a/custom_components/nefiteasy/switch.py
+++ b/custom_components/nefiteasy/switch.py
@@ -26,7 +26,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         elif key == "weather_dependent":
             entities.append(NefitWeatherDependent(client, data, key, typeconf))
         elif key == "home_entrance_detection":
-            await setup_home_entrance_detection(entities, client, data, key, typeconf)
+            continue
+        #    await setup_home_entrance_detection(entities, client, data, key, typeconf)
         else:
             entities.append(NefitSwitch(client, data, key, typeconf))
 
@@ -36,18 +37,17 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 async def setup_home_entrance_detection(entities, client, data, basekey, basetypeconf):
     """Home entrance detection setup."""
     for i in range(0, 10):
-        userprofile_id = f"userprofile{i}"
-        endpoint = f"/ecus/rrc/homeentrancedetection/{userprofile_id}/"
-        is_active = await client.get_value(userprofile_id, endpoint + "active")
-        _LOGGER.debug("hed switch: is_active: %s", is_active)
-        if is_active == "on":
-            name = await client.get_value(userprofile_id, endpoint + "name")
+        if f"presence{i}_name" in client.coordinator.data:
+            name = client.coordinator.data[f"presence{i}_name"]
+            endpoint = f"/ecus/rrc/homeentrancedetection/userprofile{i}/detected"
+
             typeconf = {}
             typeconf["name"] = basetypeconf["name"].format(name)
-            typeconf["url"] = endpoint + "detected"
+            typeconf["url"] = endpoint
             typeconf["icon"] = basetypeconf["icon"]
+
             entities.append(
-                NefitSwitch(client, data, f"{basekey}_{userprofile_id}", typeconf)
+                NefitSwitch(client, data, f"presence{i}_detected", typeconf)
             )
 
 
@@ -57,7 +57,7 @@ class NefitSwitch(NefitEntity, SwitchEntity):
     @property
     def is_on(self):
         """Get whether the switch is in on state."""
-        return self._client.data[self._key] == "on"
+        return self.coordinator.data.get(self._key) == "on"
 
     @property
     def assumed_state(self) -> bool:
@@ -66,7 +66,7 @@ class NefitSwitch(NefitEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the entity on."""
-        self._client.nefit.put_value(self.get_endpoint(), "on")
+        self.coordinator.nefit.put_value(self.get_endpoint(), "on")
 
         _LOGGER.debug(
             "Switch Nefit %s ON, endpoint=%s.", self._key, self.get_endpoint()
@@ -74,7 +74,7 @@ class NefitSwitch(NefitEntity, SwitchEntity):
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the entity off."""
-        self._client.nefit.put_value(self.get_endpoint(), "off")
+        self.coordinator.nefit.put_value(self.get_endpoint(), "off")
 
         _LOGGER.debug(
             "Switch Nefit %s OFF, endpoint=%s.", self._key, self.get_endpoint()
@@ -88,14 +88,11 @@ class NefitHotWater(NefitSwitch):
         """Initialize the switch."""
         super().__init__(client, data, key, typeconf)
 
-        self._client.keys["/dhwCircuits/dhwA/dhwOperationClockMode"] = self._key
-        self._client.keys["/dhwCircuits/dhwA/dhwOperationManualMode"] = self._key
-
     def get_endpoint(self):
         """Get end point."""
         endpoint = (
             "dhwOperationClockMode"
-            if self._client.data.get("user_mode") == "clock"
+            if self.coordinator.data.get("user_mode") == "clock"
             else "dhwOperationManualMode"
         )
         return "/dhwCircuits/dhwA/" + endpoint
@@ -107,17 +104,17 @@ class NefitWeatherDependent(NefitSwitch):
     @property
     def is_on(self):
         """Get whether the switch is in on state."""
-        return self._client.data[self._key] == "weather"
+        return self.coordinator.data.get(self._key) == "weather"
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the entity on."""
-        self._client.nefit.put_value(self.get_endpoint(), "weather")
+        self.coordinator.nefit.put_value(self.get_endpoint(), "weather")
 
         _LOGGER.debug("Switch weather dependent ON, endpoint=%s.", self.get_endpoint())
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the entity off."""
-        self._client.nefit.put_value(self.get_endpoint(), "room")
+        self.coordinator.nefit.put_value(self.get_endpoint(), "room")
 
         _LOGGER.debug("Switch weather dependent OFF, endpoint=%s.", self.get_endpoint())
 
@@ -128,11 +125,11 @@ class NefitSwitchTrueFalse(NefitEntity, SwitchEntity):
     @property
     def is_on(self):
         """Get whether the switch is in on state."""
-        return self._client.data[self._key] == "true"
+        return self.coordinator.data.get(self._key) == "true"
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the entity on."""
-        self._client.nefit.put_value(self.get_endpoint(), "true")
+        self.coordinator.nefit.put_value(self.get_endpoint(), "true")
 
         _LOGGER.debug(
             "Switch Nefit %s ON, endpoint=%s.", self._key, self.get_endpoint()
@@ -140,7 +137,7 @@ class NefitSwitchTrueFalse(NefitEntity, SwitchEntity):
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the entity off."""
-        self._client.nefit.put_value(self.get_endpoint(), "false")
+        self.coordinator.nefit.put_value(self.get_endpoint(), "false")
 
         _LOGGER.debug(
             "Switch Nefit %s OFF, endpoint=%s.", self._key, self.get_endpoint()

--- a/custom_components/nefiteasy/switch.py
+++ b/custom_components/nefiteasy/switch.py
@@ -4,7 +4,7 @@ import logging
 
 from homeassistant.components.switch import SwitchEntity
 
-from .const import CONF_SWITCHES, DOMAIN, SWITCH_TYPES
+from .const import DOMAIN, SWITCH_TYPES
 from .nefit_entity import NefitEntity
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
Refactor data update to work through DataUpdateCoordinator.

This has the advantage that:
- All endpoint fetching is done at a central point and available for all entities
- For endpoints which depend on other endpoints (for example, for the current or next switchpoint, the active program number is needed to fetch the active program) can be implemented more easily because all data is available for all entities.

Furthermore it makes the code a bit cleaner, -74 lines of code and the logic of fetching data is centrally located in `__init__.py`.

For sensors/switches, the url is added to the list when the entity is added to hass. Disabled entities are not added by hass, so these are excluded from the update coordinator.