### PR TITLE
Add temperature entity

### DIFF
--- a/custom_components/nefiteasy/const.py
+++ b/custom_components/nefiteasy/const.py
@@ -103,6 +103,15 @@ SENSORS: tuple[NefitSensorEntityDescription, ...] = (
         url="/dhwCircuits/dhwA/dhwOperationType",
         entity_registry_enabled_default=False,
     ),
+    NefitSensorEntityDescription(
+        key="inhouse_temperature",
+        name="Inhouse temperature",
+        short="IHT",
+        unit=TEMP_CELSIUS,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
 )
 
 SWITCHES: tuple[NefitSwitchEntityDescription, ...] = (


### PR DESCRIPTION
Since long term statistics are available for sensor entities, it makes sense to have a separate sensor entity. Disabled by default not to cause additional events. Based on already available status data, so no additional polling needed.