### PR TITLE
Add connection validation to config flow and add tests

### DIFF
--- a/custom_components/nefiteasy/climate.py
+++ b/custom_components/nefiteasy/climate.py
@@ -132,8 +132,6 @@ class NefitThermostat(CoordinatorEntity, ClimateEntity):
     @property
     def preset_mode(self) -> str:
         """Return the current preset mode."""
-        if self.coordinator.data.get("user_mode") == "manual":
-            return OPERATION_MANUAL
         if self.coordinator.data.get("user_mode") == "clock":
             return OPERATION_CLOCK
 

--- a/custom_components/nefiteasy/config_flow.py
+++ b/custom_components/nefiteasy/config_flow.py
@@ -1,16 +1,20 @@
 """Config flow for Nefit Easy Bosch Thermostat integration."""
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
-from homeassistant import config_entries
+from aionefit import NefitCore
+from homeassistant import config_entries, core, exceptions
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 import voluptuous as vol
 
 from .const import (  # pylint:disable=unused-import
+    AUTH_ERROR_CREDENTIALS,
+    AUTH_ERROR_PASSWORD,
     CONF_ACCESSKEY,
     CONF_MAX_TEMP,
     CONF_MIN_TEMP,
@@ -22,6 +26,85 @@ from .const import (  # pylint:disable=unused-import
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class NefitConnection:
+    """Test the connection to NefitEasy and check read to verify description of messages."""
+
+    def __init__(self, serial_number: str, access_key: str, password: str) -> None:
+        """Initialize."""
+        self.nefit = NefitCore(
+            serial_number=serial_number,
+            access_key=access_key,
+            password=password,
+        )
+
+        self.nefit.failed_auth_handler = self.failed_auth_handler
+        self.nefit.no_content_callback = self.no_content_callback
+        self.nefit.session_end_callback = self.session_end_callback
+
+        self.auth_failure = None
+
+    async def failed_auth_handler(self, event: str) -> None:
+        """Report failed auth."""
+        self.nefit.xmppclient.connected_event.set()
+
+        if event == "auth_error_password":
+            self.auth_failure = AUTH_ERROR_PASSWORD
+            _LOGGER.debug("Invalid password for connecting to Bosch cloud.")
+        else:
+            self.auth_failure = AUTH_ERROR_CREDENTIALS
+            _LOGGER.debug(
+                "Invalid credentials (serial or accesskey) for connecting to Bosch cloud."
+            )
+
+    async def session_end_callback(self) -> None:
+        """Session end."""
+
+    async def no_content_callback(self, data: Any) -> None:
+        """No content."""
+
+    async def validate_connect(self) -> None:
+        """Test if we can connect and communicate with the device."""
+
+        await self.nefit.connect()
+        try:
+            await asyncio.wait_for(
+                self.nefit.xmppclient.connected_event.wait(), timeout=10.0
+            )
+        except asyncio.TimeoutError as ex:
+            self.nefit.xmppclient.cancel_connection_attempt()
+            raise CannotConnect from ex
+
+        if self.auth_failure == AUTH_ERROR_CREDENTIALS:
+            raise InvalidCredentials
+
+        self.nefit.get("/gateway/brandID")
+        try:
+            await asyncio.wait_for(
+                self.nefit.xmppclient.message_event.wait(), timeout=10.0
+            )
+        except asyncio.TimeoutError as ex:
+            self.nefit.xmppclient.cancel_connection_attempt()
+            raise CannotCommunicate from ex
+
+        self.nefit.xmppclient.message_event.clear()
+
+        await self.nefit.disconnect()
+
+        if self.auth_failure == AUTH_ERROR_PASSWORD:
+            raise InvalidPassword
+
+
+async def _validate_nefiteasy_connection(
+    hass: core.HomeAssistant, data: dict[str, Any]
+) -> None:
+    """Validate the user input allows us to connect."""
+    conn = NefitConnection(
+        data.get(CONF_SERIAL), data[CONF_ACCESSKEY], data[CONF_PASSWORD]
+    )
+
+    await conn.validate_connect()
 
 
 class NefitEasyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -46,11 +129,23 @@ class NefitEasyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(user_input[CONF_SERIAL])
             self._abort_if_unique_id_configured()
 
-            self._serial = user_input[CONF_SERIAL]
-            self._accesskey = user_input[CONF_ACCESSKEY]
-            self._password = user_input[CONF_PASSWORD]
+            try:
+                await _validate_nefiteasy_connection(self.hass, user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except CannotCommunicate:
+                errors["base"] = "cannot_communicate"
+            except InvalidCredentials:
+                errors["base"] = "invalid_credentials"
+            except InvalidPassword:
+                errors["base"] = "invalid_password"
 
-            return await self.async_step_options()
+            if not errors:
+                self._serial = user_input[CONF_SERIAL]
+                self._accesskey = user_input[CONF_ACCESSKEY]
+                self._password = user_input[CONF_PASSWORD]
+
+                return await self.async_step_options()
 
         schema = vol.Schema(
             {
@@ -92,11 +187,18 @@ class NefitEasyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="options", data_schema=schema, errors=errors
         )
 
-    async def async_step_import(self, import_config: ConfigType) -> FlowResult:
-        """Handle the initial step."""
-        await self.async_set_unique_id(import_config[CONF_SERIAL])
-        self._abort_if_unique_id_configured()
 
-        return self.async_create_entry(
-            title=f"{import_config[CONF_SERIAL]}", data=import_config
-        )
+class CannotConnect(exceptions.HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class CannotCommunicate(exceptions.HomeAssistantError):
+    """Error to indicate we cannot communicate."""
+
+
+class InvalidCredentials(exceptions.HomeAssistantError):
+    """Error to indicate we cannot verify credentials."""
+
+
+class InvalidPassword(exceptions.HomeAssistantError):
+    """Error to indicate we cannot verify password."""

--- a/custom_components/nefiteasy/config_flow.py
+++ b/custom_components/nefiteasy/config_flow.py
@@ -47,8 +47,6 @@ class NefitConnection:
 
     async def failed_auth_handler(self, event: str) -> None:
         """Report failed auth."""
-        self.nefit.xmppclient.connected_event.set()
-
         if event == "auth_error_password":
             self.auth_failure = AUTH_ERROR_PASSWORD
             _LOGGER.debug("Invalid password for connecting to Bosch cloud.")
@@ -57,6 +55,8 @@ class NefitConnection:
             _LOGGER.debug(
                 "Invalid credentials (serial or accesskey) for connecting to Bosch cloud."
             )
+
+        self.nefit.xmppclient.connected_event.set()
 
     async def session_end_callback(self) -> None:
         """Session end."""
@@ -85,7 +85,7 @@ class NefitConnection:
                 self.nefit.xmppclient.message_event.wait(), timeout=10.0
             )
         except asyncio.TimeoutError as ex:
-            self.nefit.xmppclient.cancel_connection_attempt()
+            await self.nefit.disconnect()
             raise CannotCommunicate from ex
 
         self.nefit.xmppclient.message_event.clear()

--- a/custom_components/nefiteasy/const.py
+++ b/custom_components/nefiteasy/const.py
@@ -33,6 +33,9 @@ STATE_CONNECTION_VERIFIED = "connection_verified"
 STATE_INIT = "initializing"
 STATE_ERROR_AUTH = "authentication_failed"
 
+AUTH_ERROR_PASSWORD = "auth_error_password"
+AUTH_ERROR_CREDENTIALS = "auth_error_credentials"
+
 name = "name"
 url = "url"
 unit = "unit"

--- a/custom_components/nefiteasy/strings.json
+++ b/custom_components/nefiteasy/strings.json
@@ -18,8 +18,10 @@
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "cannot_communicate": "Failed to communicate",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "invalid_credentials": "Invalid serial number / access key combination",
+      "invalid_password": "Invalid password"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"

--- a/custom_components/nefiteasy/translations/en.json
+++ b/custom_components/nefiteasy/translations/en.json
@@ -5,8 +5,11 @@
         },
         "error": {
             "cannot_connect": "Failed to connect",
+            "cannot_communicate": "Failed to communicate",
             "invalid_auth": "Invalid authentication",
-            "unknown": "Unexpected error"
+            "unknown": "Unexpected error",
+            "invalid_credentials": "Invalid serial number / access key combination",
+            "invalid_password": "Invalid password"
         },
         "step": {
             "options": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,12 +180,15 @@ class ClientMock:
 
         self.data = json.loads(load_fixture("nefit_data.json"))
 
+        self.failed_auth_handler = None
+
     def get(self, path):
         """Get data."""
         if path in self.data:
             loop = asyncio.get_event_loop()
-            coroutine = self.callback(self.data[path])
-            loop.create_task(coroutine)
+            if self.callback is not None:
+                coroutine = self.callback(self.data[path])
+                loop.create_task(coroutine)
 
         self.xmppclient.message_event.set()
 
@@ -194,7 +197,7 @@ class ClientMock:
         self.xmppclient.connected_event.set()
 
         self.serial_number = self.mock.call_args_list[0][1]["serial_number"]
-        self.callback = self.mock.call_args_list[0][1]["message_callback"]
+        self.callback = self.mock.call_args_list[0][1].get("message_callback")
 
         return
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,190 @@
+"""Tests of the config flow of the nefiteasy integration."""
+import asyncio
+from unittest.mock import patch
+
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
+
+from custom_components.nefiteasy import DOMAIN
+
+from .conftest import ClientMock
+
+
+@patch("custom_components.nefiteasy.config_flow.NefitCore")
+async def test_setup(mock_class, hass: HomeAssistant):
+    """Test we can setup the component."""
+    client = ClientMock(mock_class)
+    mock_class.return_value = client
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"serial": "123456789", "accesskey": "myAccessKey", "password": "mypassword"},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "options"
+    assert result["errors"] == {}
+
+    with patch("custom_components.nefiteasy.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"min_temp": 12, "max_temp": 32, "temp_step": 0.2},
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "123456789"
+    assert result["data"] == {
+        "serial": "123456789",
+        "accesskey": "myAccessKey",
+        "password": "mypassword",
+        "min_temp": 12,
+        "max_temp": 32,
+        "temp_step": 0.2,
+        "name": "Nefit",
+    }
+
+
+@patch("custom_components.nefiteasy.config_flow.NefitCore")
+async def test_setup_invalid_credentials(mock_class, hass: HomeAssistant):
+    """Test we can setup network."""
+    client = ClientMock(mock_class)
+    mock_class.return_value = client
+
+    async def connect():
+        loop = asyncio.get_event_loop()
+        coroutine = client.failed_auth_handler("auth_error")
+        loop.create_task(coroutine)
+
+    client.connect = connect
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "serial": "123456789",
+            "accesskey": "myAccessKey",
+            "password": "mypassword",
+        },
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "invalid_credentials"}
+
+
+@patch("custom_components.nefiteasy.config_flow.NefitCore")
+async def test_setup_invalid_password(mock_class, hass: HomeAssistant):
+    """Test we can setup network."""
+    client = ClientMock(mock_class)
+    mock_class.return_value = client
+
+    def get(path):
+        loop = asyncio.get_event_loop()
+        coroutine = client.failed_auth_handler("auth_error_password")
+        loop.create_task(coroutine)
+
+        client.xmppclient.message_event.set()
+
+    client.get = get
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "serial": "123456789",
+            "accesskey": "myAccessKey",
+            "password": "mypassword",
+        },
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "invalid_password"}
+
+
+@patch("custom_components.nefiteasy.config_flow.NefitCore")
+async def test_setup_connect_timeout(mock_class, hass: HomeAssistant):
+    """Test we can setup network."""
+    client = ClientMock(mock_class)
+    mock_class.return_value = client
+
+    async def wait():
+        raise asyncio.TimeoutError
+
+    client.xmppclient.connected_event.wait = wait
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "serial": "123456789",
+            "accesskey": "myAccessKey",
+            "password": "mypassword",
+        },
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+@patch("custom_components.nefiteasy.config_flow.NefitCore")
+async def test_setup_message_timeout(mock_class, hass: HomeAssistant):
+    """Test we can setup network."""
+    client = ClientMock(mock_class)
+    mock_class.return_value = client
+
+    async def wait():
+        raise asyncio.TimeoutError
+
+    client.xmppclient.message_event.wait = wait
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "serial": "123456789",
+            "accesskey": "myAccessKey",
+            "password": "mypassword",
+        },
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "cannot_communicate"}


### PR DESCRIPTION
Adds a connection validation to config flow to avoid adding configuration with wrong serial, access key or password.

Add tests for config flow to get 100% coverage.