### PR TITLE
Fixed Holiday mode setting issue #173

### DIFF
--- a/custom_components/nefiteasy/climate.py
+++ b/custom_components/nefiteasy/climate.py
@@ -48,10 +48,13 @@ async def async_setup_entry(
     entities = []
 
     client = hass.data[DOMAIN][config_entry.entry_id]["client"]
+    climate = NefitThermostat(client, config_entry.data)
 
-    entities.append(NefitThermostat(client, config_entry.data))
+    entities.append(climate)
 
     async_add_entities(entities, update_before_add=True)
+
+    hass.data[DOMAIN][config_entry.entry_id]["climate"] = climate
 
 
 class NefitThermostat(CoordinatorEntity, ClimateEntity):

--- a/custom_components/nefiteasy/switch.py
+++ b/custom_components/nefiteasy/switch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 from types import MappingProxyType
 from typing import Any
+from datetime import datetime, timedelta
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
@@ -14,6 +15,7 @@ from . import NefitEasy
 from .const import DOMAIN, SWITCHES
 from .models import NefitSwitchEntityDescription
 from .nefit_entity import NefitEntity
+from .climate import OPERATION_CLOCK
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,6 +34,8 @@ async def async_setup_entry(
     for description in SWITCHES:
         if description.key == "hot_water":
             entities.append(NefitHotWater(description, client, data))
+        elif description.key == "holiday_mode":
+            entities.append(NefitHolidayMode(description, client, data, config_entry))
         elif description.key == "lockui":
             entities.append(NefitSwitch(description, client, data, "true", "false"))
         elif description.key == "weather_dependent":
@@ -143,3 +147,103 @@ class NefitHotWater(NefitSwitch):
             else "dhwOperationManualMode"
         )
         return "/dhwCircuits/dhwA/" + endpoint
+
+
+class NefitHolidayMode(NefitSwitch):
+    """Class for nefit holiday mode entity.
+
+       Note it only works if the thermostat preset is set to Clock
+    """
+
+    climate_entity = None
+    climate_preset = None
+    config_entry   = None
+
+    def __init__(
+        self,
+        entity_description: NefitEntityDescription,
+        client: NefitEasy,
+        data: MappingProxyType[str, Any],
+        config_entry: ConfigEntry,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(entity_description, client, data)
+
+        self.config_entry = config_entry
+
+    def get_climate_entity( self ):
+        if self.climate_entity is None:
+            self.climate_entity = self.hass.data[DOMAIN][self.config_entry.entry_id][ "climate" ]
+
+        return self.climate_entity
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the entity on."""
+
+        # Save and current preset mode and change it to Clock
+        self.climate_preset = self.get_climate_entity().preset_mode
+
+        _LOGGER.debug(
+            "Forcing thermostat preset mode to %s, previous mode %s.",
+            OPERATION_CLOCK,
+            self.climate_preset,
+        )
+
+        await self.get_climate_entity().async_set_preset_mode(OPERATION_CLOCK)
+
+        _LOGGER.info(
+            "Thermostat preset mode set to %s during Holiday mode operation.",
+            OPERATION_CLOCK,
+        )
+
+        holiday_start_ep = "/heatingCircuits/hc1/holidayMode/start"
+        holiday_end_ep   = "/heatingCircuits/hc1/holidayMode/end"
+
+        holiday_start_time = datetime.now().strftime("%Y-%m-%dT00:00:00")
+
+        # Add 6 months
+        holiday_end_time = ( datetime.now() + timedelta(days=180) ).strftime("%Y-%m-%dT00:00:00")
+
+        _LOGGER.debug(
+            "Setting holiday end date to %s, endpoint=%s.",
+            holiday_end_time,
+            holiday_end_ep,
+        )
+
+        self._client.nefit.put_value( holiday_end_ep, holiday_end_time)
+
+        _LOGGER.debug(
+            "Setting holiday start date to %s, endpoint=%s.",
+            holiday_start_time,
+            holiday_start_ep,
+        )
+
+        self._client.nefit.put_value( holiday_start_ep, holiday_start_time)
+
+        _LOGGER.info(
+            "Holiday mode starts from %s, and until %s.",
+            holiday_start_time,
+            holiday_end_time,
+        )
+
+        await super().async_turn_on( **kwargs )
+
+        self._client.nefit.put_value( "/heatingCircuits/hc1/holidayMode/activated", self._on_value)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the entity off."""
+
+        self._client.nefit.put_value( "/heatingCircuits/hc1/holidayMode/activated", self._off_value)
+
+        await super().async_turn_off( **kwargs )
+
+        # Setting the preset mode back to original
+        if self.climate_preset is not None:
+            await self.get_climate_entity().async_set_preset_mode(self.climate_preset)
+
+            _LOGGER.info(
+                "Thermostat preset restored to %s after Holiday mode operation was cancelled.",
+                self.climate_preset,
+            )
+
+            self.climate_preset = None


### PR DESCRIPTION
Link to issue: https://github.com/ksya/ha-nefiteasy/issues/173

Setting the holiday mode requires advanced logic to mimic what the Nefit app does

Setting Holiday mode ON:
1. Set the thermostat preset mode to Clock
2. Set Holiday mode start date endpoint to today 00:00 AM
3. Set Holiday mode end date endpoint +6 months after the start date
4. Set Holiday mode switch ON
5. Set Holiday mode active endpoint (not exposed as switch) ON

Setting Holiday mode OFF:
1. Set Holiday mode active endpoint OFF
2. Set Holiday mode switch OFF
3. Restore previous thermostat preset