### PR TITLE
Fix slow reconnect and dirty request state on timeout

### DIFF
--- a/custom_components/nefiteasy/__init__.py
+++ b/custom_components/nefiteasy/__init__.py
@@ -313,6 +313,6 @@ class NefitEasy(DataUpdateCoordinator):
         try:
             await asyncio.wait_for(self._event.wait(), timeout=9)
         except asyncio.TimeoutError:
-            self._request = ""
             raise
-        self._request = ""
+        finally:
+            self._request = ""

--- a/custom_components/nefiteasy/__init__.py
+++ b/custom_components/nefiteasy/__init__.py
@@ -1,4 +1,5 @@
 """Support for first generation Bosch smart home thermostats: Nefit Easy, Junkers CT100 etc."""
+
 from __future__ import annotations
 
 import asyncio
@@ -226,6 +227,10 @@ class NefitEasy(DataUpdateCoordinator):
             self.connected_state = STATE_INIT
             self.expected_end = False
 
+            # Schedule an immediate reconnect rather than waiting up to 60s
+            # for the next scheduled poll cycle.
+            self.hass.async_create_task(self.async_refresh())
+
     async def parse_message(self, data: dict[str, Any]) -> None:
         """Message received callback function for the XMPP client."""
         if (
@@ -305,5 +310,9 @@ class NefitEasy(DataUpdateCoordinator):
         self._event.clear()
         self._request = url
         self.nefit.get(url)
-        await asyncio.wait_for(self._event.wait(), timeout=9)
+        try:
+            await asyncio.wait_for(self._event.wait(), timeout=9)
+        except asyncio.TimeoutError:
+            self._request = ""
+            raise
         self._request = ""


### PR DESCRIPTION
## Summary

Two related fixes for the periodic `climate.nefit` unavailability caused by Bosch's XMPP cloud dropping the session (a normal server-side event that happens every few hours). Both issues have been observed and reported repeatedly — see #243, #271, #298, #318, #425.

---

### Fix 1 — `session_end_callback`: schedule immediate reconnect

**Problem:** When the XMPP session is dropped by the Bosch server, `session_end_callback()` resets `connected_state` to `STATE_INIT` but does nothing else. The next reconnect attempt only happens on the next `DataUpdateCoordinator` poll — up to 60 seconds later. During that window `climate.nefit` stays unavailable.

This is the root cause of the widely-used reload-automation workaround mentioned in #318 (and adopted by many other users in those threads).

**Fix:** After resetting state, schedule an immediate `async_refresh()` via `async_create_task` so reconnection happens within seconds rather than waiting for the next poll cycle.

```python
self.hass.async_create_task(self.async_refresh())
```

---

### Fix 2 — `_async_get_url`: clear `self._request` on timeout

**Problem:** When `asyncio.wait_for` times out, `self._request` is never cleared (the cleanup line is after the `await`). If a late XMPP response for that URL arrives during the *next* update cycle, `parse_message()` sees `self._request == data["id"]` and calls `self._event.set()`, incorrectly waking the wrong `wait_for`. This can cause a spurious success or a cascading timeout on the following request.

**Fix:** Wrap `wait_for` in `try/except asyncio.TimeoutError` and clear `self._request` in the except branch before re-raising.

```python
try:
    await asyncio.wait_for(self._event.wait(), timeout=9)
except asyncio.TimeoutError:
    self._request = ""
    raise
self._request = ""
```

---

## Related issues

- #243 — Frequent disconnects
- #271 — Disconnect / connect error notifications
- #298 — timeout fetching nefiteasy data with version 0.4.2
- #318 — Connection drops - a lot (explicitly mentions reload-automation workaround)
- #425 — Component disconnecting

## Testing

Tested on HA Core 2026.5.2 with nefiteasy v0.4.7. Monitored over several days: `Timeout fetching nefiteasy data` errors still appear occasionally (Bosch cloud dropping the session is unavoidable) but `climate.nefit` recovers within a few seconds rather than waiting 60 s for the next poll. The reload-automation workaround has not fired since applying these fixes.