### PR TITLE
ci: update pre-commit hooks (black & pyupgrade) for Python 3.12+ compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.0
+    rev: v3.19.1
     hooks:
       - id: pyupgrade
-        args: [--py38-plus]
+        args: [--py310-plus]
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 24.10.0
     hooks:
       - id: black
         args:

--- a/custom_components/nefiteasy/climate.py
+++ b/custom_components/nefiteasy/climate.py
@@ -1,4 +1,5 @@
 """Support for Bosch home thermostats."""
+
 from __future__ import annotations
 
 import asyncio

--- a/custom_components/nefiteasy/config_flow.py
+++ b/custom_components/nefiteasy/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for Nefit Easy Bosch Thermostat integration."""
+
 from __future__ import annotations
 
 import asyncio

--- a/custom_components/nefiteasy/const.py
+++ b/custom_components/nefiteasy/const.py
@@ -1,4 +1,5 @@
 """Constants for the nefiteasy component."""
+
 from __future__ import annotations
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass

--- a/custom_components/nefiteasy/models.py
+++ b/custom_components/nefiteasy/models.py
@@ -1,4 +1,5 @@
 """Models for the nefiteasy integration."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/custom_components/nefiteasy/number.py
+++ b/custom_components/nefiteasy/number.py
@@ -1,4 +1,5 @@
 """Support for Bosch home thermostats."""
+
 from __future__ import annotations
 
 import logging

--- a/custom_components/nefiteasy/select.py
+++ b/custom_components/nefiteasy/select.py
@@ -1,4 +1,5 @@
 """Support for Bosch home thermostats."""
+
 from __future__ import annotations
 
 import logging

--- a/custom_components/nefiteasy/sensor.py
+++ b/custom_components/nefiteasy/sensor.py
@@ -1,4 +1,5 @@
 """Support for Bosch home thermostats."""
+
 from __future__ import annotations
 
 from contextlib import suppress

--- a/custom_components/nefiteasy/switch.py
+++ b/custom_components/nefiteasy/switch.py
@@ -1,4 +1,5 @@
 """Support for Bosch home thermostats."""
+
 from __future__ import annotations
 
 import logging

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Test configuration of the nefiteasy integration."""
+
 import asyncio
 import json
 from unittest.mock import MagicMock, patch

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,4 +1,5 @@
 """Tests of the nefiteasy climate integration."""
+
 from homeassistant.components.climate import (
     DOMAIN as CLIMATE_DOMAIN,
     SERVICE_SET_PRESET_MODE,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests of the config flow of the nefiteasy integration."""
+
 import asyncio
 from unittest.mock import patch
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,4 +1,5 @@
 """Tests of the initialization of the nefiteasy integration."""
+
 import asyncio
 from unittest.mock import patch
 

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,4 +1,5 @@
 """Tests of the nefiteasy number integration."""
+
 from datetime import timedelta
 
 from freezegun.api import FrozenDateTimeFactory

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,4 +1,5 @@
 """Tests of the nefiteasy select integration."""
+
 from datetime import timedelta
 
 from freezegun.api import FrozenDateTimeFactory

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests of the nefiteasy sensor integration."""
+
 from datetime import timedelta
 
 from freezegun.api import FrozenDateTimeFactory

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,4 +1,5 @@
 """Tests of the nefiteasy sensor integration."""
+
 from datetime import timedelta
 
 from freezegun.api import FrozenDateTimeFactory


### PR DESCRIPTION
### Problem
The CI linter workflows (`Check black` and `Check other linters`) are currently failing across all pull requests running on Python 3.12+ runtimes due to outdated pre-commit hook versions:
- `black` version `22.3.0` (released in 2022) crashes on Python 3.12+ due to event loop changes (`RuntimeError: There is no current event loop in thread 'MainThread'`).
- `pyupgrade` version `v2.29.0` (released in 2021) crashes on Python 3.12+ due to removed `ast` attributes (`ast.Str`).

### Solution
1. Update `pyupgrade` to `v3.19.1` (`--py310-plus`).
2. Update `black` to `24.10.0`.
3. Format all codebase files with updated `black` & `pyupgrade` to restore green CI checks.