### PR TITLE
feat: add hardware version and boiler diagnostic sensors (disabled by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ Some entities are disabled by default, if needed they can be enabled. Entities t
 | system_pressure | System pressure | Bar | System water pressure | &#x2714; |
 | target_temperature | Target temperature | °C | Target temperature | &#x274C; |
 | year_total | Year total | m<sup>3</sup> | Volume of gas consumed since Jan 1<sup>st</sup> | &#x2714; |
+| firmware_version | Firmware version | | Firmware version installed on thermostat | &#x274C; |
+| hardware_version | Hardware revision | | Hardware revision of thermostat unit | &#x274C; |
+| refill_needed | Refill needed | | Alert when boiler water pressure drops low and needs refilling | &#x274C; |
+| system_leaking | System leak detected | | Leak detection alert for heating system pressure drops | &#x274C; |
+| ignition_status | Ignition status | | Burner ignition failure warning indicator | &#x274C; |
+| closing_valve_status | Gas valve status | | Gas valve / closing valve fault warning indicator | &#x274C; |
+| maintenance_request | Boiler maintenance required | | Boiler maintenance or service required indicator | &#x274C; |
 
 #### Sensor values
 

--- a/custom_components/nefiteasy/const.py
+++ b/custom_components/nefiteasy/const.py
@@ -128,6 +128,55 @@ SENSORS: tuple[NefitSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),
+    NefitSensorEntityDescription(
+        key="firmware_version",
+        name="Firmware version",
+        url="/gateway/versionFirmware",
+        icon="mdi:information-outline",
+        entity_registry_enabled_default=False,
+    ),
+    NefitSensorEntityDescription(
+        key="hardware_version",
+        name="Hardware revision",
+        url="/gateway/versionHardware",
+        icon="mdi:chip",
+        entity_registry_enabled_default=False,
+    ),
+    NefitSensorEntityDescription(
+        key="refill_needed",
+        name="Refill needed",
+        url="/ecus/rrc/pm/refillneeded/status",
+        icon="mdi:water-alert",
+        entity_registry_enabled_default=False,
+    ),
+    NefitSensorEntityDescription(
+        key="system_leaking",
+        name="System leak detected",
+        url="/ecus/rrc/pm/systemleaking/status",
+        icon="mdi:pipe-leak",
+        entity_registry_enabled_default=False,
+    ),
+    NefitSensorEntityDescription(
+        key="ignition_status",
+        name="Ignition status",
+        url="/ecus/rrc/pm/ignition/status",
+        icon="mdi:fire-alert",
+        entity_registry_enabled_default=False,
+    ),
+    NefitSensorEntityDescription(
+        key="closing_valve_status",
+        name="Gas valve status",
+        url="/ecus/rrc/pm/closingvalve/status",
+        icon="mdi:valve-closed",
+        entity_registry_enabled_default=False,
+    ),
+    NefitSensorEntityDescription(
+        key="maintenance_request",
+        name="Boiler maintenance required",
+        url="/system/appliance/boilermaintenancerequest",
+        icon="mdi:wrench-clock",
+        entity_registry_enabled_default=False,
+    ),
 )
 
 SWITCHES: tuple[NefitSwitchEntityDescription, ...] = (


### PR DESCRIPTION
### Summary
Adds 7 confirmed working hardware version & boiler maintenance/diagnostic sensors to `nefiteasy`. All 7 new sensors have `entity_registry_enabled_default=False` so they remain disabled by default unless explicitly enabled by the user in Home Assistant.

### Added Sensors
1. **Firmware Version** (`/gateway/versionFirmware`): Thermostat firmware version (e.g. `02.22.00`).
2. **Hardware Revision** (`/gateway/versionHardware`): Thermostat hardware revision (e.g. `4`).
3. **Refill Needed** (`/ecus/rrc/pm/refillneeded/status`): Alert when boiler water pressure drops low and needs refilling.
4. **System Leak Detected** (`/ecus/rrc/pm/systemleaking/status`): Heating system pressure drop leak detection alert.
5. **Ignition Status** (`/ecus/rrc/pm/ignition/status`): Burner ignition failure warning indicator.
6. **Gas Valve Status** (`/ecus/rrc/pm/closingvalve/status`): Gas valve / closing valve fault warning indicator.
7. **Boiler Maintenance Required** (`/system/appliance/boilermaintenancerequest`): Boiler service required indicator.

### Verification
- Tested live on physical Nefit Easy hardware (`02.22.00` / Revision `4`).
- Verified live state updates in Home Assistant upon enabling entities (`firmware_version` -> `02.22.00`, `hardware_version` -> `4`, maintenance/alarm states -> `false`).
- Updated `README.md` documentation table for available sensors.