### PR TITLE
Fix recovery after silent Bosch session drops

### DIFF
--- a/custom_components/nefiteasy/__init__.py
+++ b/custom_components/nefiteasy/__init__.py
@@ -130,6 +130,12 @@ class NefitEasy(DataUpdateCoordinator):
             _LOGGER.debug("Set is connecting to true")
             self.is_connecting = True
 
+            # Events from a previous session may still be set; without
+            # clearing them the waits below would return instantly and
+            # verify against a dead transport. Clear BEFORE connecting
+            # so a genuine handshake can set them again afterwards.
+            self.nefit.xmppclient.connected_event.clear()
+            self.nefit.xmppclient.message_event.clear()
             await self.nefit.connect()
             _LOGGER.debug("Waiting for connected event.")
             try:
@@ -218,14 +224,13 @@ class NefitEasy(DataUpdateCoordinator):
 
     async def session_end_callback(self) -> None:
         """If connection is closed unexpectedly, try to reconnect."""
-        if not self.expected_end:
+        if not self.expected_end and self.connected_state != STATE_INIT:
             _LOGGER.debug(
                 f"Unexpected disconnect of {self.serial} with Bosch server. Try to reconnect.."
             )
 
             # Reset values
             self.connected_state = STATE_INIT
-            self.expected_end = False
 
             # Schedule an immediate reconnect rather than waiting up to 60s
             # for the next scheduled poll cycle.

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -115,10 +115,7 @@ async def test_connect_clears_stale_events(mock_class, hass: HomeAssistant):
 @patch("custom_components.nefiteasy.NefitCore")
 async def test_duplicate_session_end_suppression(mock_class, hass: HomeAssistant):
     """Test that duplicate unexpected session_end calls only schedule a single refresh."""
-    from custom_components.nefiteasy.const import (
-        STATE_CONNECTION_VERIFIED,
-        STATE_INIT,
-    )
+    from custom_components.nefiteasy.const import STATE_CONNECTION_VERIFIED, STATE_INIT
 
     client = ClientMock(mock_class)
     mock_class.return_value = client
@@ -141,5 +138,3 @@ async def test_duplicate_session_end_suppression(mock_class, hass: HomeAssistant
         # Duplicate unexpected disconnect arriving immediately after
         await coordinator.session_end_callback()
         assert mock_refresh.call_count == 1
-
-

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -81,3 +81,65 @@ async def test_setup_validation_fail_timeout(mock_class, hass: HomeAssistant):
     await hass.async_block_till_done()
 
     assert config_entry.state == config_entries.ConfigEntryState.SETUP_RETRY
+
+
+@patch("custom_components.nefiteasy.NefitCore")
+async def test_connect_clears_stale_events(mock_class, hass: HomeAssistant):
+    """Test that stale events from a previous session are cleared before connect."""
+    client = ClientMock(mock_class)
+    mock_class.return_value = client
+
+    # Pre-set stale events as if left over from a previous session
+    client.xmppclient.connected_event.set()
+    client.xmppclient.message_event.set()
+
+    # Reconnect fails to produce new handshake event
+    async def fake_connect():
+        pass
+
+    async def timeout_wait():
+        raise asyncio.TimeoutError
+
+    client.connect = fake_connect
+    client.xmppclient.connected_event.wait = timeout_wait
+
+    config_entry = MockConfigEntry(domain="nefiteasy", data=entry_data)
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state == config_entries.ConfigEntryState.SETUP_RETRY
+
+
+@patch("custom_components.nefiteasy.NefitCore")
+async def test_duplicate_session_end_suppression(mock_class, hass: HomeAssistant):
+    """Test that duplicate unexpected session_end calls only schedule a single refresh."""
+    from custom_components.nefiteasy.const import (
+        STATE_CONNECTION_VERIFIED,
+        STATE_INIT,
+    )
+
+    client = ClientMock(mock_class)
+    mock_class.return_value = client
+
+    config_entry = MockConfigEntry(domain="nefiteasy", data=entry_data)
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = hass.data["nefiteasy"][config_entry.entry_id]["client"]
+    assert coordinator.connected_state == STATE_CONNECTION_VERIFIED
+
+    with patch.object(coordinator, "async_refresh") as mock_refresh:
+        # First unexpected disconnect
+        await coordinator.session_end_callback()
+        assert coordinator.connected_state == STATE_INIT
+        assert mock_refresh.call_count == 1
+
+        # Duplicate unexpected disconnect arriving immediately after
+        await coordinator.session_end_callback()
+        assert mock_refresh.call_count == 1
+
+


### PR DESCRIPTION
## Motivation

The Bosch XMPP gateway periodically drops sessions **without sending a
stream close**. Measured over 96 h on a production instance (34
events), drop intervals cluster tightly at 60–69 min and 120–129 min
after session start — absolute server-side session lifetime caps, not
idle timeouts: the connection carries poll traffic every ~60 s, and
whitespace keepalive plus XEP-0199 ping are already active.

Because no `session_end` event fires, the coordinator retries
`connect()` against a stale transport — and because NefitCore's
`asyncio.Events` remain set from the dead session, that connect()
"verified" instantly against a socket that could not carry traffic.
Requests then failed within milliseconds on every cycle until
something external reloaded the config entry. Live-observed worst
case: 14 minutes of failure loops until a manual restart.

## Changes

* Clear `connected_event` / `message_event` **before** initiating
  `connect()`: stale flags are removed, and a genuine handshake sets
  them again — so verification once more requires real responses.
* Harden `session_end_callback`: guard on the connection state so
  duplicate events cannot schedule multiple refreshes, and drop the
  redundant reset of `expected_end` inside the branch that only runs
  when it is already false.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| Silent session drop (hourly) | Instant-failure loop until external reload; entities unavailable ≥30 s, sometimes hours | Genuine reconnect; self-recovery in 1–4 min |
| Duplicate `session_end` events | Multiple concurrent refresh tasks possible | Single refresh |

## Validation

Dogfooded on a production instance with debug logging and the user's
reload-automation disabled. After deploying this branch the same
failure mode self-recovered at 19:04, 19:38, 19:44–19:50 (repeated
gateway kicks) and 19:56 — no external reload needed at any point,
whereas the pre-fix build had required one earlier that day.

Independent of #460; either PR can merge in any order.

